### PR TITLE
added installation instructions to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,15 @@ This APP is currently under development.
 #### License
 
 GNU GENERAL PUBLIC LICENSE (v3)
+
+### Installation
+
+1.) in the command line
+
+    home/frappe/frappe-bench/
+    bench get-app livechat https://github.com/semilimes/livechat
+
+2.) in the ERPNext GUI
+
+- Type "App Installer" in the 'awesome bar' (on the Top right) and open it
+- find the "livechat" app & click on 'install'


### PR DESCRIPTION
as the title says. Added installation instructions as below to the README. 
Please kindly consider to merge this

---------------
**Installation**

1.) in the command line

home/frappe/frappe-bench/
bench get-app livechat https://github.com/semilimes/livechat

2.) in the ERPNext GUI

    Type "App Installer" in the 'awesome bar' (on the Top right) and open it
    find the "livechat" app & click on 'install'
